### PR TITLE
Not use session

### DIFF
--- a/Controller/Component/QuestionnairesComponent.php
+++ b/Controller/Component/QuestionnairesComponent.php
@@ -511,6 +511,15 @@ class QuestionnairesComponent extends Component {
 	const QUESTIONNAIRE_FINGER_PRINT_FILENAME = 'finger_print.txt';
 
 /**
+ * Answered questionnaire keys
+ *
+ * 回答済みアンケートキー配列
+ *
+ * @var array
+ */
+	private $__ownAnsweredKeys = null;
+
+/**
  * getDisplayNumberOptions
  *
  * @return array
@@ -612,5 +621,49 @@ class QuestionnairesComponent extends Component {
 			return true;
 		}
 		return false;
+	}
+
+/**
+ * 回答済みアンケートリストを取得する
+ *
+ * 回答済みデータをルーム毎に保持したほうが良いかも
+ *
+ * @return Answered Questionnaire keys list
+ */
+	public function getOwnAnsweredKeys() {
+		if (isset($this->__ownAnsweredKeys)) {
+			return $this->__ownAnsweredKeys;
+		}
+
+		$this->__ownAnsweredKeys  = array();
+
+		if (empty(Current::read('User.id'))) {
+			$cookie = $this->_Collection->load('Cookie');
+			$keys = $cookie->read('answeredQuestionnaireKeys');
+			if (isset($keys)) {
+				$this->__ownAnsweredKeys = explode(',', $answeredQuestionnaires);
+			}
+
+			return $this->__ownAnsweredKeys;
+		}
+
+		$questionnaireAnswerSummary = ClassRegistry::init('Questionnaires.QuestionnaireAnswerSummary');
+		$conditions = array(
+			'user_id' => Current::read('User.id'),
+			'answer_status' => QuestionnairesComponent::ACTION_ACT,
+			'test_status' => QuestionnairesComponent::TEST_ANSWER_STATUS_PEFORM,
+			'answer_number' => 1
+		);
+		$keys = $questionnaireAnswerSummary->find(
+			'list',
+			array(
+				'conditions' => $conditions,
+				'fields' => array('QuestionnaireAnswerSummary.questionnaire_key'),
+				'recursive' => -1
+			)
+		);
+		$this->__ownAnsweredKeys = array_values($keys);	// idの使用を防ぐ（いらない？）
+
+		return $this->__ownAnsweredKeys;
 	}
 }

--- a/Controller/Component/QuestionnairesComponent.php
+++ b/Controller/Component/QuestionnairesComponent.php
@@ -626,7 +626,7 @@ class QuestionnairesComponent extends Component {
 /**
  * 回答済みアンケートリストを取得する
  *
- * 回答済みデータをルーム毎に保持したほうが良いかも
+ * 回答済みデータをブロック毎に保持したほうが良いかも
  *
  * @return Answered Questionnaire keys list
  */
@@ -638,10 +638,10 @@ class QuestionnairesComponent extends Component {
 		$this->__ownAnsweredKeys = array();
 
 		if (empty(Current::read('User.id'))) {
-			$cookie = $this->_Collection->load('Cookie');
-			$keys = $cookie->read('answeredQuestionnaireKeys');
-			if (isset($keys)) {
-				$this->__ownAnsweredKeys = explode(',', $keys);
+			$session = $this->_Collection->load('Session');
+			$ownAnsweredKeys = $session->read('Questionnaires.ownAnsweredKeys');
+			if (isset($ownAnsweredKeys)) {
+				$this->__ownAnsweredKeys = explode(',', $ownAnsweredKeys);
 			}
 
 			return $this->__ownAnsweredKeys;
@@ -654,7 +654,7 @@ class QuestionnairesComponent extends Component {
 			'test_status' => QuestionnairesComponent::TEST_ANSWER_STATUS_PEFORM,
 			'answer_number' => 1
 		);
-		$keys = $answerSummary->find(
+		$ownAnsweredKeys = $answerSummary->find(
 			'list',
 			array(
 				'conditions' => $conditions,
@@ -662,7 +662,7 @@ class QuestionnairesComponent extends Component {
 				'recursive' => -1
 			)
 		);
-		$this->__ownAnsweredKeys = array_values($keys);	// idの使用を防ぐ（いらない？）
+		$this->__ownAnsweredKeys = array_values($ownAnsweredKeys);	// idの使用を防ぐ（いらない？）
 
 		return $this->__ownAnsweredKeys;
 	}

--- a/Controller/Component/QuestionnairesComponent.php
+++ b/Controller/Component/QuestionnairesComponent.php
@@ -635,26 +635,26 @@ class QuestionnairesComponent extends Component {
 			return $this->__ownAnsweredKeys;
 		}
 
-		$this->__ownAnsweredKeys  = array();
+		$this->__ownAnsweredKeys = array();
 
 		if (empty(Current::read('User.id'))) {
 			$cookie = $this->_Collection->load('Cookie');
 			$keys = $cookie->read('answeredQuestionnaireKeys');
 			if (isset($keys)) {
-				$this->__ownAnsweredKeys = explode(',', $answeredQuestionnaires);
+				$this->__ownAnsweredKeys = explode(',', $keys);
 			}
 
 			return $this->__ownAnsweredKeys;
 		}
 
-		$questionnaireAnswerSummary = ClassRegistry::init('Questionnaires.QuestionnaireAnswerSummary');
+		$answerSummary = ClassRegistry::init('Questionnaires.QuestionnaireAnswerSummary');
 		$conditions = array(
 			'user_id' => Current::read('User.id'),
 			'answer_status' => QuestionnairesComponent::ACTION_ACT,
 			'test_status' => QuestionnairesComponent::TEST_ANSWER_STATUS_PEFORM,
 			'answer_number' => 1
 		);
-		$keys = $questionnaireAnswerSummary->find(
+		$keys = $answerSummary->find(
 			'list',
 			array(
 				'conditions' => $conditions,

--- a/Controller/QuestionnairesController.php
+++ b/Controller/QuestionnairesController.php
@@ -100,7 +100,7 @@ class QuestionnairesController extends QuestionnairesAppController {
 			)
 		);
 		if (!isset($this->params['named']['answer_status'])) {
-			$this->request->params['named']['answer_status'] =  QuestionnairesComponent::QUESTIONNAIRE_ANSWER_VIEW_ALL;
+			$this->request->params['named']['answer_status'] = QuestionnairesComponent::QUESTIONNAIRE_ANSWER_VIEW_ALL;
 		}
 		$questionnaire = $this->paginate('Questionnaire', $this->_getPaginateFilter());
 		$this->set('questionnaires', $questionnaire);
@@ -128,8 +128,7 @@ class QuestionnairesController extends QuestionnairesAppController {
 			return $filter;
 		}
 
-		$ownAnsweredKeys = $this->Questionnaires->getOwnAnsweredKeys();
-		$filterCondition = array('Questionnaire.key' => $ownAnsweredKeys);
+		$filterCondition = array('Questionnaire.key' => $this->Questionnaires->getOwnAnsweredKeys());
 		if ($this->request->params['named']['answer_status'] == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_UNANSWERED) {
 			$filter = array(
 				'NOT' => $filterCondition

--- a/Controller/QuestionnairesController.php
+++ b/Controller/QuestionnairesController.php
@@ -86,7 +86,7 @@ class QuestionnairesController extends QuestionnairesAppController {
 		$conditions = $this->Questionnaire->getCondition();
 
 		// データ取得
-		$subQuery = $this->Questionnaire->getQuestionnaireSubQuery();
+		//$subQuery = $this->Questionnaire->getQuestionnaireSubQuery();
 		$this->Paginator->settings = array_merge(
 			$this->Paginator->settings,
 			array(
@@ -96,11 +96,16 @@ class QuestionnairesController extends QuestionnairesAppController {
 				'limit' => $displayNum,
 				'direction' => $dir,
 				'recursive' => 0,
-				'joins' => $subQuery,
+				//'joins' => $subQuery,
 			)
 		);
+		if (!isset($this->params['named']['answer_status'])) {
+			$this->request->params['named']['answer_status'] =  QuestionnairesComponent::QUESTIONNAIRE_ANSWER_VIEW_ALL;
+		}
 		$questionnaire = $this->paginate('Questionnaire', $this->_getPaginateFilter());
 		$this->set('questionnaires', $questionnaire);
+
+		$this->__setOwnAnsweredKeys();
 
 		if (count($questionnaire) == 0) {
 			$this->view = 'Questionnaires/noQuestionnaire';
@@ -113,25 +118,44 @@ class QuestionnairesController extends QuestionnairesAppController {
  * @return array
  */
 	protected function _getPaginateFilter() {
-		$answerStatus = isset($this->params['named']['answer_status']) ? $this->params['named']['answer_status'] : QuestionnairesComponent::QUESTIONNAIRE_ANSWER_VIEW_ALL;
-		if ($answerStatus == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_UNANSWERED) {
-			$filter = array(
-				'OR' => array(
-					array('answer_summary_count' => null),
-					array('answer_summary_count' => 0)
-				)
-			);
-		} elseif ($answerStatus == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_ANSWERED) {
-			$filter = array(
-				'answer_summary_count >' => 0
-			);
-		} elseif ($answerStatus == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_TEST) {
+		$filter = array();
+
+		if ($this->request->params['named']['answer_status'] == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_TEST) {
 			$filter = array(
 				'Questionnaire.status !=' => WorkflowComponent::STATUS_PUBLISHED
 			);
-		} else {
-			$filter = array();
+
+			return $filter;
 		}
+
+		$ownAnsweredKeys = $this->Questionnaires->getOwnAnsweredKeys();
+		$filterCondition = array('Questionnaire.key' => $ownAnsweredKeys);
+		if ($this->request->params['named']['answer_status'] == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_UNANSWERED) {
+			$filter = array(
+				'NOT' => $filterCondition
+			);
+		} elseif ($this->request->params['named']['answer_status'] == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_ANSWERED) {
+			$filter = array(
+				$filterCondition
+			);
+		}
+
 		return $filter;
 	}
+
+/**
+ * Set view value of answered questionnaire keys
+ *
+ * @return void
+ */
+	private function __setOwnAnsweredKeys() {
+		if ($this->request->params['named']['answer_status'] == QuestionnairesComponent::QUESTIONNAIRE_ANSWER_UNANSWERED) {
+			$this->set('ownAnsweredKeys', array());
+
+			return;
+		}
+
+		$this->set('ownAnsweredKeys', $this->Questionnaires->getOwnAnsweredKeys());
+	}
+
 }

--- a/Model/Questionnaire.php
+++ b/Model/Questionnaire.php
@@ -349,8 +349,17 @@ class Questionnaire extends QuestionnairesAppModel {
 	public function getCondition($addConditions = array()) {
 		// ベースとなる権限のほかに現在フレームに表示設定されているアンケートか見ている
 		$conditions = $this->getBaseCondition($addConditions);
-		$conditions['NOT'] = array('QuestionnaireFrameDisplayQuestionnaires.id' => null);
-		$conditions['QuestionnaireFrameDisplayQuestionnaires.frame_key'] = Current::read('Frame.key');
+
+		$questionnaireFrameDisplayQuestionnaires = ClassRegistry::init('Questionnaires.QuestionnaireFrameDisplayQuestionnaires');
+		$keys = $questionnaireFrameDisplayQuestionnaires->find(
+			'list',
+			array(
+				'conditions' => array('QuestionnaireFrameDisplayQuestionnaires.frame_key' => Current::read('Frame.key')),
+				'fields' => array('QuestionnaireFrameDisplayQuestionnaires.questionnaire_key'),
+				'recursive' => -1
+			)
+		);
+		$conditions['Questionnaire.key'] = $keys;
 
 		if ($addConditions) {
 			$conditions = array_merge($conditions, $addConditions);

--- a/Model/Questionnaire.php
+++ b/Model/Questionnaire.php
@@ -350,8 +350,8 @@ class Questionnaire extends QuestionnairesAppModel {
 		// ベースとなる権限のほかに現在フレームに表示設定されているアンケートか見ている
 		$conditions = $this->getBaseCondition($addConditions);
 
-		$questionnaireFrameDisplayQuestionnaires = ClassRegistry::init('Questionnaires.QuestionnaireFrameDisplayQuestionnaires');
-		$keys = $questionnaireFrameDisplayQuestionnaires->find(
+		$frameDisplay = ClassRegistry::init('Questionnaires.QuestionnaireFrameDisplayQuestionnaires');
+		$keys = $frameDisplay->find(
 			'list',
 			array(
 				'conditions' => array('QuestionnaireFrameDisplayQuestionnaires.frame_key' => Current::read('Frame.key')),

--- a/View/Helper/QuestionnaireUtilHelper.php
+++ b/View/Helper/QuestionnaireUtilHelper.php
@@ -115,7 +115,7 @@ class QuestionnaireUtilHelper extends AppHelper {
 		// 期間外だったら操作不可能
 		// 繰り返し回答不可で回答済なら操作不可能
 		if ($questionnaire['Questionnaire']['period_range_stat'] != QuestionnairesComponent::QUESTIONNAIRE_PERIOD_STAT_IN
-			|| (isset($questionnaire['Questionnaire']['answer_summary_count']) && $questionnaire['Questionnaire']['answer_summary_count'] > 0
+			|| (in_array($key, $this->_View->viewVars['ownAnsweredKeys'])
 				&& $questionnaire['Questionnaire']['is_repeat_allow'] == QuestionnairesComponent::PERMISSION_NOT_PERMIT)) {
 			$answerButtonClass = 'default';
 			$answerButtonDisabled = 'disabled';
@@ -126,7 +126,7 @@ class QuestionnaireUtilHelper extends AppHelper {
 			// 未公開
 			$answerButtonLabel = __d('questionnaires', 'Unpublished');
 		}
-		if (isset($questionnaire['Questionnaire']['answer_summary_count']) && $questionnaire['Questionnaire']['answer_summary_count'] > 0) {
+		if (in_array($key, $this->_View->viewVars['ownAnsweredKeys']) ) {
 			// 回答済み
 			$answerButtonLabel = __d('questionnaires', 'Finished');
 		}
@@ -171,7 +171,7 @@ class QuestionnaireUtilHelper extends AppHelper {
 			} else {
 				// 集計結果公開期間内である
 				// 一つでも回答している
-				if (empty($questionnaire['Questionnaire']['answer_summary_count']) && !$force) {
+				if (!in_array($key, $this->_View->viewVars['ownAnsweredKeys']) && !$force) {
 					// 未回答
 					$disabled = 'disabled';
 				}

--- a/View/Helper/QuestionnaireUtilHelper.php
+++ b/View/Helper/QuestionnaireUtilHelper.php
@@ -126,7 +126,7 @@ class QuestionnaireUtilHelper extends AppHelper {
 			// 未公開
 			$answerButtonLabel = __d('questionnaires', 'Unpublished');
 		}
-		if (in_array($key, $this->_View->viewVars['ownAnsweredKeys']) ) {
+		if (in_array($key, $this->_View->viewVars['ownAnsweredKeys'])) {
 			// 回答済み
 			$answerButtonLabel = __d('questionnaires', 'Finished');
 		}


### PR DESCRIPTION
セッションを使用せず、クッキーを使用して回答済みの判断をするよう大枠作ってみました。
残機能としては、

１．回答完了でSession書き込み
https://github.com/NetCommons3/Questionnaires/blob/90ca24a09fc2a4bb3121248cabaabfd3f4ae766c/Controller/QuestionnaireAnswersController.php#L255
に追加になると思います。

２．回答中データ取得処理
https://github.com/NetCommons3/Questionnaires/blob/72587bca2454127be9909da24ff2aa78f99262e3/Model/QuestionnaireAnswerSummary.php#L159
に回答開始というこで、セッションにarray(アンケートキー.回答集計ID（summaries_id）)を書き込む感じかと思います。


結果、Sessionの内容は
```
array(
    'Questionnaires' => array(
        'OwnAnsweredKeys' => array(
            'questionnaireKey001',
            'questionnaireKey002',
            'questionnaireKey003',
        )
    ),
    'Questionnaires' => array(
        'MiddleOfAnswer' => array(
            'questionnaireKey005' => 100,
            'questionnaireKey006' => 222,
            'questionnaireKey007' => 333,
        )
    )
)
```
の状態になると思われます。