### PR TITLE
フォーム編集でチェックボックスにチェックが入った状態から始めるとng-show使ってても非表示にならない。ng-false-value, …

### DIFF
--- a/View/Helper/QuestionEditHelper.php
+++ b/View/Helper/QuestionEditHelper.php
@@ -89,7 +89,10 @@ class QuestionEditHelper extends AppHelper {
 			'class' => '',
 			'error' => false,
 			'ng-model' => $ngModel,
-			'ng-checked' => $ngModel . '==' . QuestionnairesComponent::USES_USE),
+			//'ng-checked' => $ngModel . '==' . RegistrationsComponent::USES_USE,
+			'ng-false-value' => '"0"', // この記述でないと チェックON,OFFが正常に動作しない。
+			'ng-true-value' => '"1"'
+		),
 			$options
 		);
 

--- a/View/QuestionnaireEdit/edit.ctp
+++ b/View/QuestionnaireEdit/edit.ctp
@@ -63,9 +63,9 @@ $jsQuestionnaire = NetCommonsAppController::camelizeKeyRecursive(QuestionnairesA
 						__d('questionnaires', 'set the answer period'),
 						array(
 						'value' => WorkflowBehavior::PUBLIC_TYPE_LIMITED,
-						'ng-checked' => 'questionnaires.questionnaire.publicType==' . "'" . WorkflowBehavior::PUBLIC_TYPE_LIMITED . "'",
-						'ng-true-value' => WorkflowBehavior::PUBLIC_TYPE_LIMITED,
-						'ng-false-value' => WorkflowBehavior::PUBLIC_TYPE_PUBLIC,
+						//'ng-checked' => 'questionnaires.questionnaire.publicType==' . "'" . WorkflowBehavior::PUBLIC_TYPE_LIMITED . "'",
+						'ng-true-value' => '"' . WorkflowBehavior::PUBLIC_TYPE_LIMITED . '"',
+						'ng-false-value' => '"' . WorkflowBehavior::PUBLIC_TYPE_PUBLIC .'"' ,
 						'hiddenField' => WorkflowBehavior::PUBLIC_TYPE_PUBLIC
 						),
 						__d('questionnaires', 'After approval will be immediately published . Stop of the questionnaire to select the stop from the questionnaire data list .'));


### PR DESCRIPTION
フォーム編集でチェックボックスにチェックが入った状態から始めるとng-show使ってても非表示にならない。ng-false-value, ng-true-valueをクォート有り文字列にすることで正常に動作するようになった
